### PR TITLE
Update job ID validation to conditionally include application options

### DIFF
--- a/app/controllers/api/v0/api_controller.rb
+++ b/app/controllers/api/v0/api_controller.rb
@@ -56,11 +56,11 @@ module Api
         end
       end
 
-      def verify_path_listed_job_id
+      def verify_path_listed_job_id(include_application_options)
         if id_blank_or_invalid?
           blank_error('job')
         else
-          validate_listed_job_id
+          validate_listed_job_id(include_application_options)
         end
       end
 
@@ -172,8 +172,12 @@ module Api
         not_found_error('job')
       end
 
-      def validate_listed_job_id
-        @job = Job.find(params[:id])
+      def validate_listed_job_id(include_application_options)
+        @job = if include_application_options
+                 Job.includes(:application_options).find(params[:id])
+               else
+                 Job.find(params[:id])
+               end
         removed_error('job') unless @job.job_status == 'listed' && @job.activity_status == 1
       rescue ActiveRecord::RecordNotFound
         not_found_error('job')

--- a/app/controllers/api/v0/applications_controller.rb
+++ b/app/controllers/api/v0/applications_controller.rb
@@ -7,7 +7,7 @@ module Api
       include ApplicationBuilder
       before_action :verify_path_job_id, except: %i[show_all create accept reject pipeline]
       before_action :verify_path_active_job_id, only: %i[accept reject]
-      before_action :verify_path_listed_job_id, only: %i[create]
+      before_action -> { verify_path_listed_job_id(true) }, only: %i[create]
       before_action :must_be_verified!
       before_action :must_be_subscribed!, only: %i[accept reject]
 


### PR DESCRIPTION
Applications submitted manually or via genius could were not working, as the @job object didn't include the attached application options.